### PR TITLE
[Issue #14] Fix README install.sh URL to reference main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The script will:
 
 **To reinstall afterward:**
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Kali-AI-term/test/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Kali-AI-term/main/install.sh)
 ```
 
 ### Manual Installation


### PR DESCRIPTION
## Summary

- Fixes the "To reinstall afterward" curl command in README.md — was pointing to the `test` branch, now correctly points to `main`
- Single-line targeted fix with zero risk of regression
- No logic changes; documentation only

## Change

**Before:**
```bash
bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Kali-AI-term/test/install.sh)
```

**After:**
```bash
bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Kali-AI-term/main/install.sh)
```

## Test Plan

- [ ] Verify the curl URL resolves correctly against the `main` branch
- [ ] Confirm `install.sh` exists on `main` (it does — visible in repo root)
- [ ] No other files modified

Closes #14