### PR TITLE
fix: Dockerfile docker.sock mkdir prevents app container from starting (#39)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN npm ci --only=production
 COPY server.js ./
 COPY public ./public
 
-# Create directories for socket and data
-RUN mkdir -p /app/data /var/run/docker.sock
+# Create data directory
+RUN mkdir -p /app/data
 
 # Expose port
 EXPOSE 3000


### PR DESCRIPTION
## Summary

Fixes **#39** — `kali-ai-term-app` stuck in `Created` state, port `31337` unreachable.

### Root Cause

```dockerfile
# BEFORE — creates /var/run/docker.sock as a DIRECTORY
RUN mkdir -p /app/data /var/run/docker.sock
```

Docker cannot bind-mount the host's Unix socket file (`/var/run/docker.sock`) over a path that already exists as a **directory** inside the container image. The OCI runtime fails at container start, leaving `kali-ai-term-app` permanently in `Created` state.

### Fix

```dockerfile
# AFTER — only create the data directory
RUN mkdir -p /app/data
```

Remove `/var/run/docker.sock` from the `mkdir` command. The bind mount in `docker-compose.yml` creates this path correctly at runtime:

```yaml
volumes:
  - /var/run/docker.sock:/var/run/docker.sock
```

### Files Changed

| File | Change |
|------|--------|
| `Dockerfile` | Removed `/var/run/docker.sock` from `RUN mkdir -p` (line 20) |

### Test Plan

- [ ] `docker compose build` completes without errors
- [ ] `docker compose up -d` starts both `kali-ai-term-kali` and `kali-ai-term-app`
- [ ] `docker ps` shows `kali-ai-term-app` status as `Up` (not `Created`)
- [ ] `curl http://localhost:31337/api/system/status` returns HTTP 200
- [ ] App healthcheck passes within 30s start period

### Diagnostic Confirmation

From the issue diagnostic:
- `kali-ai-term-app` → `Created` ← fixed by this PR
- Port `31337` → `Connection refused` ← fixed by this PR
- `kali-ai-term-kali` → `Up (healthy)` ← unaffected

---

> ⚠️ **MERGE REQUEST — Human review required. Do NOT auto-merge.**
> This PR was created by an autonomous agent. Please review the single-line change before merging to `main`.