### PR TITLE
fix: resolve docker.sock MS_BIND|MS_REC mount failure (#41)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: .
@@ -14,8 +12,14 @@ services:
       - KALI_CONTAINER=kali-ai-term-kali
       - LOG_LEVEL=info
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./data:/app/data
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        bind:
+          propagation: private
+      - type: bind
+        source: ./data
+        target: /app/data
     depends_on:
       - kali
     networks:

--- a/install.js
+++ b/install.js
@@ -36,6 +36,30 @@ async function checkPrerequisites() {
     missingDeps.push('docker');
   }
 
+  // Check Docker socket accessibility (Linux/macOS only)
+  // Newer Docker Engine (24+) / runc (1.1.x+) changed default bind propagation
+  // to rprivate (MS_REC), which fails for socket files. Catching this early
+  // gives a clear error instead of a cryptic OCI runtime failure.
+  if (process.platform !== 'win32') {
+    try {
+      const sockStat = fs.statSync('/var/run/docker.sock');
+      if (!sockStat.isSocket()) {
+        logger.error(
+          '/var/run/docker.sock exists but is not a socket file — check your Docker installation'
+        );
+        missingDeps.push('docker-socket');
+      } else {
+        logger.success('Docker socket accessible at /var/run/docker.sock');
+      }
+    } catch (err) {
+      logger.error(
+        'Docker socket not found at /var/run/docker.sock — is the Docker daemon running?',
+        { hint: 'Try: sudo systemctl start docker' }
+      );
+      missingDeps.push('docker-socket');
+    }
+  }
+
   // Check Docker Compose
   let hasCompose = false;
   try {


### PR DESCRIPTION
## Summary

Fixes #41 — critical installation failure where `kali-ai-term-app` container cannot start due to a Docker socket mount error introduced by Docker Engine 24+ / runc 1.1.x+.

## Root Cause

Docker Engine 24+ changed the default bind mount propagation to `rprivate` (recursive private), which applies the `MS_REC` kernel flag to **all** bind mounts. The Linux kernel requires the source to be a **directory** when `MS_REC` is used. A Unix socket file (`/var/run/docker.sock`) is not a directory, so the mount syscall fails:

```
flags=MS_BIND|MS_REC: not a directory
```

## Changes

### `docker-compose.yml`
- **Converted** the `docker.sock` volume from short syntax to long-form `type: bind` with explicit `propagation: private` — this uses `MS_BIND` only (no `MS_REC`), which correctly handles socket files on all Docker versions
- **Converted** `./data` bind mount to matching long-form syntax for consistency  
- **Removed** deprecated `version: '3.8'` key (Compose v2 ignores it and emits the warning visible in the issue logs)

### `install.js`
- **Added** Docker socket pre-flight check in `checkPrerequisites()` that validates `/var/run/docker.sock` exists **and** is a socket file before attempting `docker compose up`
- Gives a clear human-readable error message with a remediation hint instead of the cryptic OCI runtime failure

## Test Plan

- [ ] Run `node install.js` on a system with Docker Engine 24+ — both containers should start cleanly
- [ ] Confirm no `MS_BIND|MS_REC` error in logs
- [ ] Confirm deprecation warning about `version` key is gone from compose output
- [ ] If Docker daemon is stopped, `install.js` now exits early with: `Docker socket not found at /var/run/docker.sock — is the Docker daemon running?`

---

> **DO NOT MERGE** — awaiting human review per enterprise policy. Please review and merge when ready.