### PR TITLE
fix(install): unblock streamed installer path handling

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,6 +1,6 @@
 # 📊 Kali-AI-term Strategic Planning & Coordination
 
-**Last Updated**: 2026-04-05 00:10:00 UTC  
+**Last Updated**: 2026-04-05 03:40:00 UTC  
 **Document Purpose**: Centralized planning for multi-agent coordination, architectural decisions, and project context
 
 ---
@@ -23,12 +23,15 @@
 - **Primary**: Diagnostic scripts run from deleted/invalid working directory
 - **Secondary**: Error reporting infrastructure missing (now added)
 - **Tertiary**: Security concerns with plaintext passwords + weak tokens (pre-existing)
+- **New blocker (2026-04-05)**: Streamed quick install (`bash <(curl .../install.sh)`) resolved to transient `/dev/fd` path and failed before repo checks
 
 **Solution Deployed**:
 - ✅ Login failure diagnostic reporting added (error reports in `data/login-error-reports/`)
 - ✅ Enhanced error messages with reportId for support tracking
 - ✅ Diagnostic collection script targets auth/container logs (phase 3 refinement)
 - ✅ install.sh enhanced with full debug mode (set -x tracing)
+- ✅ install.sh now detects streamed execution and bootstraps repo checkout, then hands off to install-full.sh
+- ✅ install-full.sh now hard-fails with explicit guidance when invoked from transient `/dev/fd` path
 
 **Next Steps**:
 1. User should run install/diagnostics from valid repo directory (~/Kali-AI-term)

--- a/install-full.sh
+++ b/install-full.sh
@@ -13,6 +13,14 @@ if ! pwd >/dev/null 2>&1; then
     cd "$HOME" 2>/dev/null || cd /tmp
 fi
 
+SOURCE_PATH="${BASH_SOURCE[0]}"
+if [[ "$SOURCE_PATH" == /dev/fd/* || "$SOURCE_PATH" == /proc/*/fd/* ]]; then
+    log_error() { echo "$1"; }
+    log_error "ERROR: install-full.sh should run from a real repository checkout"
+    log_error "Run: git clone https://github.com/Crashcart/Kali-AI-term.git && cd Kali-AI-term && bash install-full.sh"
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 cd "$SCRIPT_DIR"
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,23 @@ if ! pwd >/dev/null 2>&1; then
   cd "$HOME" 2>/dev/null || cd /tmp
 fi
 
+SOURCE_PATH="${BASH_SOURCE[0]}"
+if [[ "$SOURCE_PATH" == /dev/fd/* || "$SOURCE_PATH" == /proc/*/fd/* ]]; then
+  REPO_DIR="${KALI_AI_TERM_DIR:-$HOME/Kali-AI-term}"
+  REPO_URL="https://github.com/Crashcart/Kali-AI-term.git"
+
+  echo "✓ Streamed installer detected; bootstrapping repository checkout..."
+  command -v git >/dev/null 2>&1 || { echo "  ❌ git is required for streamed install"; exit 1; }
+
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    git -C "$REPO_DIR" pull --ff-only >/dev/null 2>&1 || true
+  else
+    git clone "$REPO_URL" "$REPO_DIR" >/dev/null 2>&1
+  fi
+
+  exec bash "$REPO_DIR/install-full.sh" "$@"
+fi
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 cd "$SCRIPT_DIR"
 


### PR DESCRIPTION
## Summary
- Fix blocker in streamed quick installer execution ()
- Detect transient  execution and bootstrap to real checkout
- Add explicit guard in full installer for invalid streamed path mode
- Update planning notes with blocker/remediation

## Related
- fixes #52

## Files
- install.sh
- install-full.sh
- PLANNING.md

## Validation
- bash -n install.sh
- bash -n install-full.sh